### PR TITLE
[DF-541] Update opal-connector-spec with new API routes for adding/removing group-groups

### DIFF
--- a/openapi-connector-spec.yaml
+++ b/openapi-connector-spec.yaml
@@ -421,9 +421,9 @@ paths:
         - BearerAuth: []
       tags:
         - groups
-  /groups/{group_id}/groups:
+  /groups/{group_id}/member-groups:
     post:
-      description: Add a group to the specified group
+      description: Add a member group to the specified group
       operationId: addGroupGroup
       parameters:
         - description: The ID of the parent group
@@ -442,7 +442,7 @@ paths:
             schema:
               properties:
                 group_id:
-                  description: The id of the child group to add.
+                  description: The ID of the member group to add.
                   example: f454d283-ca67-4a8a-bdbb-df212eca5353
                   type: string
                 app_id:
@@ -465,9 +465,9 @@ paths:
         - BearerAuth: []
       tags:
         - groups
-  /groups/{group_id}/groups/{member_group_id}:
+  /groups/{group_id}/member-groups/{member_group_id}:
     delete:
-      description: Remove a group from the specified group
+      description: Remove a member group from the specified group
       operationId: removeGroupGroup
       parameters:
         - description: The ID of the parent group
@@ -479,7 +479,7 @@ paths:
           schema:
             type: string
           style: simple
-        - description: The ID of the child group to remove.
+        - description: The ID of the member group to remove.
           example: f454d283-ca67-4a8a-bdbb-df212eca5353
           in: path
           explode: true

--- a/openapi-connector-spec.yaml
+++ b/openapi-connector-spec.yaml
@@ -422,8 +422,6 @@ paths:
       tags:
         - groups
   /groups/{group_id}/member-groups:
-    get:
-      description: 
     post:
       description: Add a member group to the specified group
       operationId: addGroupMemberGroup

--- a/openapi-connector-spec.yaml
+++ b/openapi-connector-spec.yaml
@@ -422,6 +422,54 @@ paths:
       tags:
         - groups
   /groups/{group_id}/member-groups:
+    get:
+      description: Get member groups for the specified group
+      operationId: getGroupMemberGroups
+      parameters:
+        - description: The ID of the parent group
+          example: f454d283-ca67-4a8a-bdbb-df212eca5353
+          in: path
+          explode: true
+          name: group_id
+          required: true
+          schema:
+            type: string
+          style: simple
+        - description: The pagination cursor value.
+          example: cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw
+          explode: true
+          in: query
+          name: cursor
+          required: false
+          schema:
+            type: string
+          style: form
+        - description: The identifier of your custom app.
+          example: my-custom-app
+          explode: true
+          in: query
+          name: app_id
+          required: true
+          schema:
+            type: string
+          style: form
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GroupMemberGroupResponse"
+          description: The member groups for the specified group
+        "401":
+          $ref: "#/components/responses/InvalidRequestSignatureError"
+        "404":
+          $ref: "#/components/responses/EntityNotFoundError"
+        default:
+          $ref: "#/components/responses/UnexpectedError"
+      security:
+        - BearerAuth: []
+      tags:
+        - groups
     post:
       description: Add a member group to the specified group
       operationId: addGroupMemberGroup
@@ -454,7 +502,7 @@ paths:
                 - app_id
       responses:
         "200":
-          description: The group was successfully added to the group.
+          description: The member group was successfully added to the group.
         "401":
           $ref: "#/components/responses/InvalidRequestSignatureError"
         "404":
@@ -1147,3 +1195,35 @@ components:
       type: object
       required:
         - resources
+    GroupMemberGroupsResponse:
+      example:
+        next_cursor: cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw
+        group_id: f454d283-ca67-4a8a-bdbb-df212eca5353
+      properties:
+        next_cursor:
+          description:
+            The cursor with which to continue pagination if additional
+            result pages exist.
+          example: cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw
+          nullable: true
+          type: string
+        groups:
+          items:
+            type: object
+            properties:
+              group_id:
+                description: 
+                example: f454d283-ca67-4a8a-bdbb-df212eca5353
+                type: string
+              name:
+                description:
+                example: Test Group
+                type: string
+              description: 
+                description:
+                example: Test Group Description
+                type: string
+      type: object
+      required:
+        - groups
+        - next_cursor

--- a/openapi-connector-spec.yaml
+++ b/openapi-connector-spec.yaml
@@ -422,9 +422,11 @@ paths:
       tags:
         - groups
   /groups/{group_id}/member-groups:
+    get:
+      description: 
     post:
       description: Add a member group to the specified group
-      operationId: addGroupGroup
+      operationId: addGroupMemberGroup
       parameters:
         - description: The ID of the parent group
           example: f454d283-ca67-4a8a-bdbb-df212eca5353
@@ -468,7 +470,7 @@ paths:
   /groups/{group_id}/member-groups/{member_group_id}:
     delete:
       description: Remove a member group from the specified group
-      operationId: removeGroupGroup
+      operationId: removeGroupMemberGroup
       parameters:
         - description: The ID of the parent group
           example: f454d283-ca67-4a8a-bdbb-df212eca5353

--- a/openapi-connector-spec.yaml
+++ b/openapi-connector-spec.yaml
@@ -488,19 +488,15 @@ paths:
           schema:
             type: string
           style: simple
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              properties:
-                app_id:
-                  description: The identifier of your custom app.
-                  example: my-custom-app
-                  type: string
-              required:
-                - group_id
-                - app_id
+        - description: The identifier of your custom app.
+          example: my-custom-app
+          explode: true
+          in: query
+          name: app_id
+          required: true
+          schema:
+            type: string
+          style: form
       responses:
         "200":
           description: The member group was successfully removed from the group

--- a/openapi-connector-spec.yaml
+++ b/openapi-connector-spec.yaml
@@ -503,7 +503,7 @@ paths:
                 - app_id
       responses:
         "200":
-          description: The group was successfully removed from the group
+          description: The member group was successfully removed from the group
         "401":
           $ref: "#/components/responses/InvalidRequestSignatureError"
         "404":

--- a/openapi-connector-spec.yaml
+++ b/openapi-connector-spec.yaml
@@ -465,6 +465,7 @@ paths:
         - BearerAuth: []
       tags:
         - groups
+  /groups/{group_id}/groups/{member_group_id}:
     delete:
       description: Remove a group from the specified group
       operationId: removeGroupGroup
@@ -478,16 +479,21 @@ paths:
           schema:
             type: string
           style: simple
+        - description: The ID of the child group to remove.
+          example: f454d283-ca67-4a8a-bdbb-df212eca5353
+          in: path
+          explode: true
+          name: member_group_id
+          required: true
+          schema:
+            type: string
+          style: simple
       requestBody:
         required: true
         content:
           application/json:
             schema:
               properties:
-                group_id:
-                  description: The id of the child group to remove.
-                  example: f454d283-ca67-4a8a-bdbb-df212eca5353
-                  type: string
                 app_id:
                   description: The identifier of your custom app.
                   example: my-custom-app

--- a/openapi-connector-spec.yaml
+++ b/openapi-connector-spec.yaml
@@ -421,6 +421,93 @@ paths:
         - BearerAuth: []
       tags:
         - groups
+  /groups/{group_id}/groups:
+    post:
+      description: Add a group to the specified group
+      operationId: addGroupGroup
+      parameters:
+        - description: The ID of the parent group
+          example: f454d283-ca67-4a8a-bdbb-df212eca5353
+          in: path
+          explode: true
+          name: group_id
+          required: true
+          schema:
+            type: string
+          style: simple
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                group_id:
+                  description: The id of the child group to add.
+                  example: f454d283-ca67-4a8a-bdbb-df212eca5353
+                  type: string
+                app_id:
+                  description: The identifier of your custom app.
+                  example: my-custom-app
+                  type: string
+              required:
+                - group_id
+                - app_id
+      responses:
+        "200":
+          description: The group was successfully added to the group.
+        "401":
+          $ref: "#/components/responses/InvalidRequestSignatureError"
+        "404":
+          $ref: "#/components/responses/EntityNotFoundError"
+        default:
+          $ref: "#/components/responses/UnexpectedError"
+      security:
+        - BearerAuth: []
+      tags:
+        - groups
+    delete:
+      description: Remove a group from the specified group
+      operationId: removeGroupGroup
+      parameters:
+        - description: The ID of the parent group
+          example: f454d283-ca67-4a8a-bdbb-df212eca5353
+          in: path
+          explode: true
+          name: group_id
+          required: true
+          schema:
+            type: string
+          style: simple
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                group_id:
+                  description: The id of the child group to remove.
+                  example: f454d283-ca67-4a8a-bdbb-df212eca5353
+                  type: string
+                app_id:
+                  description: The identifier of your custom app.
+                  example: my-custom-app
+                  type: string
+              required:
+                - group_id
+                - app_id
+      responses:
+        "200":
+          description: The group was successfully removed from the group
+        "401":
+          $ref: "#/components/responses/InvalidRequestSignatureError"
+        "404":
+          $ref: "#/components/responses/EntityNotFoundError"
+        default:
+          $ref: "#/components/responses/UnexpectedError"
+      security:
+        - BearerAuth: []
+      tags:
+        - groups
   /groups/{group_id}/users:
     get:
       description: Returns a list of users for the specified group.

--- a/openapi-connector-spec.yaml
+++ b/openapi-connector-spec.yaml
@@ -426,7 +426,7 @@ paths:
       description: Get member groups for the specified group
       operationId: getGroupMemberGroups
       parameters:
-        - description: The ID of the parent group
+        - description: The ID of the containing group
           example: f454d283-ca67-4a8a-bdbb-df212eca5353
           in: path
           explode: true
@@ -474,7 +474,7 @@ paths:
       description: Add a member group to the specified group
       operationId: addGroupMemberGroup
       parameters:
-        - description: The ID of the parent group
+        - description: The ID of the containing group
           example: f454d283-ca67-4a8a-bdbb-df212eca5353
           in: path
           explode: true
@@ -518,7 +518,7 @@ paths:
       description: Remove a member group from the specified group
       operationId: removeGroupMemberGroup
       parameters:
-        - description: The ID of the parent group
+        - description: The ID of the containing group
           example: f454d283-ca67-4a8a-bdbb-df212eca5353
           in: path
           explode: true


### PR DESCRIPTION
Adds routes for adding/removing group-group relationships in the OpenAPI spec

Mini design doc: https://www.notion.so/opal-security/Mini-Design-Doc-Custom-Connectors-Group-Group-APIs-11ab8b94ee958009961ffd48f58ee258?pvs=4