### PR TITLE
[DF-542] Update opal-connector-spec with API routes for pulling group-groups

### DIFF
--- a/openapi-connector-spec.yaml
+++ b/openapi-connector-spec.yaml
@@ -422,6 +422,54 @@ paths:
       tags:
         - groups
   /groups/{group_id}/member-groups:
+    get:
+      description: Get member groups for the specified group
+      operationId: getGroupMemberGroups
+      parameters:
+        - description: The ID of the parent group
+          example: f454d283-ca67-4a8a-bdbb-df212eca5353
+          in: path
+          explode: true
+          name: group_id
+          required: true
+          schema:
+            type: string
+          style: simple
+        - description: The pagination cursor value.
+          example: cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw
+          explode: true
+          in: query
+          name: cursor
+          required: false
+          schema:
+            type: string
+          style: form
+        - description: The identifier of your custom app.
+          example: my-custom-app
+          explode: true
+          in: query
+          name: app_id
+          required: true
+          schema:
+            type: string
+          style: form
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GroupMemberGroupResponse"
+          description: The member groups for the specified group
+        "401":
+          $ref: "#/components/responses/InvalidRequestSignatureError"
+        "404":
+          $ref: "#/components/responses/EntityNotFoundError"
+        default:
+          $ref: "#/components/responses/UnexpectedError"
+      security:
+        - BearerAuth: []
+      tags:
+        - groups
     post:
       description: Add a member group to the specified group
       operationId: addGroupMemberGroup
@@ -454,7 +502,7 @@ paths:
                 - app_id
       responses:
         "200":
-          description: The group was successfully added to the group.
+          description: The member group was successfully added to the group.
         "401":
           $ref: "#/components/responses/InvalidRequestSignatureError"
         "404":
@@ -1147,3 +1195,27 @@ components:
       type: object
       required:
         - resources
+    GroupMemberGroupResponse:
+      example:
+        next_cursor: cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw
+        group_id: f454d283-ca67-4a8a-bdbb-df212eca5353
+      properties:
+        next_cursor:
+          description:
+            The cursor with which to continue pagination if additional
+            result pages exist.
+          example: cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw
+          nullable: true
+          type: string
+        groups:
+          items:
+            type: object
+            properties:
+              group_id:
+                description: 
+                example: f454d283-ca67-4a8a-bdbb-df212eca5353
+                type: string
+      type: object
+      required:
+        - groups
+        - next_cursor

--- a/openapi-connector-spec.yaml
+++ b/openapi-connector-spec.yaml
@@ -1215,6 +1215,14 @@ components:
                 description: 
                 example: f454d283-ca67-4a8a-bdbb-df212eca5353
                 type: string
+              name:
+                description:
+                example: Test Group
+                type: string
+              description: 
+                description:
+                example: Test Group Description
+                type: string
       type: object
       required:
         - groups

--- a/openapi-connector-spec.yaml
+++ b/openapi-connector-spec.yaml
@@ -1195,7 +1195,7 @@ components:
       type: object
       required:
         - resources
-    GroupMemberGroupResponse:
+    GroupMemberGroupsResponse:
       example:
         next_cursor: cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw
         group_id: f454d283-ca67-4a8a-bdbb-df212eca5353


### PR DESCRIPTION
Adds routes for getting group-group relationships in the OpenAPI spec

Mini design doc: https://www.notion.so/opal-security/Mini-Design-Doc-Custom-Connectors-Group-Group-APIs-11ab8b94ee958009961ffd48f58ee258?pvs=4